### PR TITLE
[Logging] - Add missing semi-colon

### DIFF
--- a/js/propForms.js
+++ b/js/propForms.js
@@ -913,4 +913,4 @@ var logging = function(code, callback, multiple) {
  
     window.onkeyup = self.init;
  
-}
+};


### PR DESCRIPTION
Prevents concatenation errors that happen when **not** prepending functions by semi-colons.